### PR TITLE
`alloc_contig_range: [x, y) PFNs busy` fixes

### DIFF
--- a/include/configs/mx6qmf0300_common.h
+++ b/include/configs/mx6qmf0300_common.h
@@ -161,7 +161,6 @@
         "androidboot.hardware=freescale " \
         "androidboot.soc_type=imx6q " \
         "androidboot.storage_type=emmc " \
-        "cma=448M " \
         "galcore.contiguousSize=33554432 " \
         "\0" \
     "bootcmd_android=run android_args;" \
@@ -185,7 +184,6 @@
         "androidboot.soc_type=imx6q " \
         "androidboot.storage_type=emmc " \
         "androidboot.selinux=permissive " \
-        "cma=448M " \
         "galcore.contiguousSize=33554432 " \
         "\0" \
     "bootcmd_android_permissive=run android_permissive_args;" \

--- a/include/configs/mx6qmf0300_common.h
+++ b/include/configs/mx6qmf0300_common.h
@@ -155,7 +155,7 @@
         "video=mxcfb1:dev=hdmi,if=RGB24,bpp=32 " \
         "video=mxcfb2:off " \
         "video=mxcfb3:off " \
-        "vmalloc=128M " \
+        "vmalloc=768M " \
         "androidboot.console=" CONFIG_CONSOLE_DEV " " \
         "consoleblank=0 " \
         "androidboot.hardware=freescale " \
@@ -178,7 +178,7 @@
         "video=mxcfb1:dev=hdmi,if=RGB24,bpp=32 " \
         "video=mxcfb2:off " \
         "video=mxcfb3:off " \
-        "vmalloc=128M " \
+        "vmalloc=768M " \
         "androidboot.console=" CONFIG_CONSOLE_DEV " " \
         "consoleblank=0 " \
         "androidboot.hardware=freescale " \


### PR DESCRIPTION
- increased vmalloc size
- dropped cma settings from kernel command line